### PR TITLE
48 feat 멋사 백엔드 스프링 1주차 과제

### DIFF
--- a/spring/week01/seminar/src/main/java/com/likelion/seminar/student/controller/StudentController.java
+++ b/spring/week01/seminar/src/main/java/com/likelion/seminar/student/controller/StudentController.java
@@ -1,4 +1,58 @@
 package com.likelion.seminar.student.controller;
 
+import com.likelion.seminar.student.dto.StudentDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("student")
 public class StudentController {
+    private final List<StudentDTO> studentDTOList;
+
+    @PostMapping()
+    public void createStudent(@RequestBody StudentDTO studentDTO) {
+        System.out.println(studentDTO.toString());
+        this.studentDTOList.add(studentDTO);
+    }
+
+    @GetMapping()
+    public List<StudentDTO> readStudentAll() {
+        System.out.println("학생 전체 조회");
+        return this.studentDTOList;
+    }
+
+    @GetMapping("{id}")
+    public StudentDTO readStudentById(@PathVariable("id") int id) {
+        System.out.println("포스트 단일 조회");
+        return this.studentDTOList.get(id);
+    }
+
+    @PutMapping("{id}")
+    public void updateStudent(
+            @PathVariable("id") int id,
+            @RequestBody StudentDTO studentDto) {
+        StudentDTO targetStudent = this.studentDTOList.get(id);
+        if(studentDto.getStudentID()!=null){
+            targetStudent.setStudentID(studentDto.getStudentID());
+        }
+        if(studentDto.getName()!=null){
+            targetStudent.setName(studentDto.getName());
+        }
+        if(studentDto.getDateOfBirth()!=null){
+            targetStudent.setDateOfBirth(studentDto.getDateOfBirth());
+        }
+        this.studentDTOList.set(id, targetStudent);
+    }
+
+    @DeleteMapping("{id}")
+    public void deleteStudent(@PathVariable("id") int id) {
+        this.studentDTOList.remove(id);
+    }
+
+
+
 }

--- a/spring/week01/seminar/src/main/java/com/likelion/seminar/student/controller/StudentController.java
+++ b/spring/week01/seminar/src/main/java/com/likelion/seminar/student/controller/StudentController.java
@@ -1,0 +1,4 @@
+package com.likelion.seminar.student.controller;
+
+public class StudentController {
+}

--- a/spring/week01/seminar/src/main/java/com/likelion/seminar/student/controller/StudentController.java
+++ b/spring/week01/seminar/src/main/java/com/likelion/seminar/student/controller/StudentController.java
@@ -25,32 +25,47 @@ public class StudentController {
         return this.studentDTOList;
     }
 
-    @GetMapping("{id}")
-    public StudentDTO readStudentById(@PathVariable("id") int id) {
-        System.out.println("포스트 단일 조회");
-        return this.studentDTOList.get(id);
+    @GetMapping("{studentID}")
+    public Object readStudent(@PathVariable("studentID") Long studentID) {
+        System.out.println("학생 단일 조회");
+        for (StudentDTO studentDto : this.studentDTOList) {
+            if (studentDto.getStudentID().equals(studentID)) {
+                return studentDto;
+            }
+        }
+        return "해당 studentID를 가진 학생이 존재하지 않습니다.";
     }
 
-    @PutMapping("{id}")
-    public void updateStudent(
-            @PathVariable("id") int id,
+    @PutMapping("{studentID}")
+    public Object updateStudent(
+            @PathVariable("studentID") Long studentID,
             @RequestBody StudentDTO studentDto) {
-        StudentDTO targetStudent = this.studentDTOList.get(id);
-        if(studentDto.getStudentID()!=null){
-            targetStudent.setStudentID(studentDto.getStudentID());
+        for (StudentDTO targetStudent : this.studentDTOList) {
+            if (targetStudent.getStudentID().equals(studentID)) {
+                if (studentDto.getName() != null) {
+                    targetStudent.setName(studentDto.getName());
+                }
+                if (studentDto.getDateOfBirth() != null) {
+                    targetStudent.setDateOfBirth(studentDto.getDateOfBirth());
+                }
+                if (studentDto.getStudentID() != null) {
+                    targetStudent.setStudentID(studentDto.getStudentID());
+                }
+                return "학생 정보 수정 완료";
+            }
         }
-        if(studentDto.getName()!=null){
-            targetStudent.setName(studentDto.getName());
-        }
-        if(studentDto.getDateOfBirth()!=null){
-            targetStudent.setDateOfBirth(studentDto.getDateOfBirth());
-        }
-        this.studentDTOList.set(id, targetStudent);
+        return "해당 studentID를 가진 학생이 존재하지 않습니다.";
     }
 
-    @DeleteMapping("{id}")
-    public void deleteStudent(@PathVariable("id") int id) {
-        this.studentDTOList.remove(id);
+    @DeleteMapping("{studentID}")
+    public Object deleteStudent(@PathVariable("studentID") Long studentID) {
+        for (StudentDTO student : this.studentDTOList) {
+            if (student.getStudentID().equals(studentID)) {
+                this.studentDTOList.remove(student);
+                return "학생이 삭제되었습니다.";
+            }
+        }
+        return "해당 studentID를 가진 학생이 존재하지 않습니다.";
     }
 
 

--- a/spring/week01/seminar/src/main/java/com/likelion/seminar/student/dto/StudentDTO.java
+++ b/spring/week01/seminar/src/main/java/com/likelion/seminar/student/dto/StudentDTO.java
@@ -1,0 +1,18 @@
+package com.likelion.seminar.student.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@ToString
+public class StudentDTO {
+    private Long studentID;
+    private String name;
+    private LocalDate dateOfBirth;
+}


### PR DESCRIPTION
## 📌 관련 이슈
closed #48 


## ✨ 과제 내용
이번 과제는 주어진 StudentDTO와 API 명세서를 보고 RESTful한 API를 구현하는 것이었습니다.

### 1. 프로젝트 초기 세팅
- student 패키지를 생성하고, 그 안에 controller, dto 패키지를 만든다.
- controller 패키지 안에 StudentController.java, dto 패키지 안에 StudentDTO.java 파일을 생성한다.

### 2. StudentDTO
- 주어진 StudentDTO에 따라 클래스를 정의한다.
- 이 클래스는 Spring에서 JSON을 자바 객체로 바꾸기 위해 필요한 클래스이다. (역직렬화)
- @Getter, @Setter, @AllArgsConstructor, @ToString 등과 같은 어노테이션을 사용하여 간단한 코드를 모두 직접 작성하지 않아도 됐다.
- 특히 @AllArgsConstructor 어노테이션을 통해, 모든 필드를 매개변수로 받는 생성자를 자동으로 만들도록 했다. 

### 3. StudentController
- createStudent (POST) -> 실습 코드와 유사하게 작성했습니다.
- readStudentAll (GET - 전체 리스트 조회) -> 실습 코드와 유사하게 작성했습니다.
- readStudent (GET - 단건 조회) 
<img width="1244" height="471" alt="image" src="https://github.com/user-attachments/assets/e11aa277-eada-43c3-a3de-4c844bd6fb1f" />

-> for문을 돌면서, 현재 리스트에 저장된 모든 학생 (StudentDTO)를 하나하나 확인 후, 요청으로 받은 값과 같은지 비교한다. 같으면 그 학생 객체 StudentDto를 반환하는데, 이때 Spring이 이 StudentDTO 객체를 알아서 직렬화해서 응답 본문으로 보내준다.  
=> 코드에서는 학생 객체만 반환해도 알아서 JSON으로 응답이 가능하다. 

- updateStudent (PUT) 
<img width="1257" height="906" alt="image" src="https://github.com/user-attachments/assets/f0daa6c0-e2ad-40bc-baff-c98f7eccf24b" />

-> GET 요청 때와 같이, for문을 돌면서 studentID가 일치하는 학생을 찾는 과정을 거치되, 세 번의 if문을 거쳐 간다. 
if문에서는 각 필드가 null인지 아닌지를 체크하고, null이 아닌 부분만 부분적으로 수정할 수 있도록 하여, 필드의 일부분만을 수정 요청해도 나머지 기존 데이터가 사라지는 것을 방지한다. 

- deleteStudent (DELETE) 
<img width="1238" height="481" alt="image" src="https://github.com/user-attachments/assets/347a85d4-9c3f-4bec-8834-ad613a4c7226" />

-> GET 요청 때와 같이, for문을 돌면서, 현재 리스트에 저장된 모든 학생 (StudentDTO)를 하나하나 확인 후, 요청으로 받은 값과 같은지 비교하는데, 이때 같으면 그 student 객체를 삭제한다. 그리고 삭제되었다는 메시지를 리턴한다. 



## 📸 스크린샷(선택)
- 학생 정보 생성하기
<img width="2006" height="853" alt="image" src="https://github.com/user-attachments/assets/b5c05a8b-c412-4adc-b308-d74e119de894" />

- 학생 정보 전체 조회하기
<img width="2021" height="1293" alt="image" src="https://github.com/user-attachments/assets/3e065575-cadb-40c8-8feb-4c6a94ec7b14" />

- 학생 정보 단건 조회하기 
여기서는 studentID=1234567인 안성민33에 대해 조회했습니다.
<img width="2016" height="885" alt="image" src="https://github.com/user-attachments/assets/d56b324f-f703-4424-9b5a-be0c3f45015d" />

- 학생 정보 수정하기
<img width="2033" height="933" alt="image" src="https://github.com/user-attachments/assets/bc57b148-35b1-4994-a161-fea49587b259" />

다음 사진에서 단건조회를 했을 때, 학번이 1234567인 학생의 정보가 올바르게 수정된 것을 확인할 수 있었습니다.
<img width="2019" height="860" alt="image" src="https://github.com/user-attachments/assets/054bd6eb-f7fa-434e-b193-9473c5d9790f" />

- 학생 정보 삭제하기
<img width="2019" height="903" alt="image" src="https://github.com/user-attachments/assets/8fe8bffc-168c-412d-92a2-7890e5cb4d4c" />

다음 사진에서 단건조회를 했을 때, 학번이 1234567인 학생의 정보가 올바르게 삭제된 것을 확인할 수 있었습니다.
<img width="2032" height="799" alt="image" src="https://github.com/user-attachments/assets/981e1262-adf2-46a9-a1f1-5dcc64934ad6" />



## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<새로 알게 된 점들>
1. public void로 선언하지 않고 public Object로 선언해야 하는 이유
-> Java는 하나의 함수에서 StudentDTO와 문자열 ""을 동시에 리턴할 수 없기 때문이다.
예를 들어 단건 조회에서 분기할 때처럼, studentID와 일치하는 요청을 받았을 때는 studentDTO 객체를 반환하고, 불일치할 때는 에러 메시지를 띄우고 싶을 때, void로 선언하면 리턴할 때 에러가 난다. 
=> 그 둘의 공통 부모 타입인 Object로 리턴 타입을 설정하면 해결된다. 

2. long 타입과 Long 타입의 차이점 (-> studentID의 타입이 long이 아닌 Long으로 주어진 이유는 무엇일까)
-> Long 타입은 long 타입과 달리 null 을 허용한다.
-> null 여부를 검사하고 싶으면 Long을 써야 한다. 만약 long이었다면 null 체크가 불가능해서 항상 값을 넘겨줘야 올바르게 작동이 됐을 거다. 


