### PR TITLE
71 feat 멋사 백엔드 8주차 과제

### DIFF
--- a/spring/week08/seminar/src/main/java/com/seminar/seminar/dto/SignupRequest.java
+++ b/spring/week08/seminar/src/main/java/com/seminar/seminar/dto/SignupRequest.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 public class SignupRequest {
 
     @NotBlank(message = "아이디는 공백일 수 없습니다.")
-    private String id;
+    private String username;
 
     @NotBlank(message = "이메일은 공백일 수 없습니다.")
     @Email(message = "이메일 형식이 올바르지 않습니다.")

--- a/spring/week08/seminar/src/main/java/com/seminar/seminar/dto/SignupRequest.java
+++ b/spring/week08/seminar/src/main/java/com/seminar/seminar/dto/SignupRequest.java
@@ -1,0 +1,28 @@
+package com.seminar.seminar.dto;
+
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SignupRequest {
+
+    @NotBlank(message = "아이디는 공백일 수 없습니다.")
+    private String id;
+
+    @NotBlank(message = "이메일은 공백일 수 없습니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 공백일 수 없습니다.")
+    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+    private String password;
+}

--- a/spring/week08/seminar/src/main/java/com/seminar/seminar/dto/SignupRequest.java
+++ b/spring/week08/seminar/src/main/java/com/seminar/seminar/dto/SignupRequest.java
@@ -23,6 +23,6 @@ public class SignupRequest {
     private String email;
 
     @NotBlank(message = "비밀번호는 공백일 수 없습니다.")
-    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+    @Size(min = 8, max = 20, message = "비밀번호는 최소 8자 이상이어야 합니다.")
     private String password;
 }

--- a/spring/week08/seminar/src/main/java/com/seminar/seminar/exception/HttpStatus.java
+++ b/spring/week08/seminar/src/main/java/com/seminar/seminar/exception/HttpStatus.java
@@ -7,6 +7,8 @@ public enum HttpStatus { // enum은 상수처럼 쓰는 객체
     UNAUTHORIZED(401, "Unauthorized"),
     FORBIDDEN(403, "Forbidden"),
     NOT_FOUND(404, "Not Found"),
+    CONFLICT(409, "Conflict"),
+    GONE(410, "Gone"),
     INTERNAL_SERVER_ERROR(500, "Internal Server Error"),
     SERVICE_UNAVAILABLE(503, "Service Unavailable");
 

--- a/spring/week08/seminar/src/main/java/com/seminar/seminar/user/User.java
+++ b/spring/week08/seminar/src/main/java/com/seminar/seminar/user/User.java
@@ -1,0 +1,27 @@
+package com.seminar.seminar.user;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false, length = 20)
+    private String username;
+
+    @Column(nullable = false, length = 50)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+}

--- a/spring/week08/seminar/src/main/java/com/seminar/seminar/user/UserController.java
+++ b/spring/week08/seminar/src/main/java/com/seminar/seminar/user/UserController.java
@@ -1,0 +1,4 @@
+package com.seminar.seminar.user;
+
+public class UserController {
+}

--- a/spring/week08/seminar/src/main/java/com/seminar/seminar/user/UserController.java
+++ b/spring/week08/seminar/src/main/java/com/seminar/seminar/user/UserController.java
@@ -1,4 +1,27 @@
 package com.seminar.seminar.user;
 
+import com.seminar.seminar.dto.SignupRequest;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
 public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<String> signup(@Valid @RequestBody SignupRequest request) {
+        userService.signup(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body("회원가입 성공");
+    }
 }

--- a/spring/week08/seminar/src/main/java/com/seminar/seminar/user/UserRepository.java
+++ b/spring/week08/seminar/src/main/java/com/seminar/seminar/user/UserRepository.java
@@ -1,4 +1,9 @@
 package com.seminar.seminar.user;
 
-public interface UserRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByUsername(String username);
 }

--- a/spring/week08/seminar/src/main/java/com/seminar/seminar/user/UserRepository.java
+++ b/spring/week08/seminar/src/main/java/com/seminar/seminar/user/UserRepository.java
@@ -1,0 +1,4 @@
+package com.seminar.seminar.user;
+
+public interface UserRepository {
+}

--- a/spring/week08/seminar/src/main/java/com/seminar/seminar/user/UserService.java
+++ b/spring/week08/seminar/src/main/java/com/seminar/seminar/user/UserService.java
@@ -1,0 +1,4 @@
+package com.seminar.seminar.user;
+
+public class UserService {
+}

--- a/spring/week08/seminar/src/main/java/com/seminar/seminar/user/UserService.java
+++ b/spring/week08/seminar/src/main/java/com/seminar/seminar/user/UserService.java
@@ -1,4 +1,39 @@
 package com.seminar.seminar.user;
 
+import com.seminar.seminar.dto.SignupRequest;
+import com.seminar.seminar.exception.CustomException;
+import com.seminar.seminar.exception.HttpStatus;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+@Service
 public class UserService {
+
+    public final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Transactional
+    public void signup(SignupRequest request) {
+        // 아이디 중복검사
+        if (userRepository.existsByUsername(request.getUsername())) {
+            throw new CustomException(HttpStatus.CONFLICT, "이미 존재하는 아이디입니다.");
+        }
+
+        // 이메일 도메인 검사
+        if (!request.getEmail().endsWith("@sookmyung.ac.kr")) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "숙명 이메일로만 가입할 수 있습니다.");
+        }
+
+        // USER 엔티티 생성 및 저장
+        User user = User.builder()
+                .username(request.getUsername())
+                .email(request.getEmail())
+                .password(request.getPassword())
+                .build();
+
+        userRepository.save(user);
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
closed #71 


## ✨ 과제 내용
이번 과제는 회원가입 API 실습을 통해 **유효성 검사**와 **예외 처리**에 대해 학습하는 내용이었습니다.
- UserController.java
- UserService.java(예외처리)
- UserRepository(아이디 중복검사 메서드)
- SignupRequestDTO(valid)
- HttpStatus



## 📸 스크린샷(선택)
### 1. 정상 요청 테스트
<img width="1769" height="900" alt="image" src="https://github.com/user-attachments/assets/6878879b-8f90-4119-8ec7-8459243616d5" />

모든 필드를 정상적으로 요청한 경우, 회원 역시 정상적으로 생성됩니다. 

### 2. 아이디 중복 테스트
<img width="1754" height="980" alt="image" src="https://github.com/user-attachments/assets/f29723a9-ec10-4779-a629-1a175f256d0b" />

중복된 아이디로 회원생성 요청을 한 경우, 409 CONFLICT 메서드와 함께 회원이 생성되지 않습니다. 
응답 포맷은 CustomExceptionHandler에서 정의한 대로 error type, code, message가 출력됩니다. 

### 3. 숙명 이메일 테스트
<img width="1750" height="977" alt="image" src="https://github.com/user-attachments/assets/592335c6-c0ef-4ec9-a1e4-350a82f15f36" />

이메일의 도메인을 @gmail.com으로 회원을 생성한 경우, 400 Bad Request 와 함께 회원이 생성되지 않습니다.

### 4. 비밀번호 길이 테스트
1) 8자보다 짧은 경우
<img width="1743" height="1346" alt="image" src="https://github.com/user-attachments/assets/11481336-4dcd-4128-9680-ec55a4eec8a1" />

비밀번호가 8자보다 짧거나 20자보다 긴 경우, 400 Bad Request와 함께 회원이 생성되지 않는데, 이때 핸들러를 등록하지 않아서 응답형식이 정돈되지 않게 나오게 되었습니다. 

2) 20자보다 긴 경우
<img width="1747" height="1304" alt="image" src="https://github.com/user-attachments/assets/a18ef15f-1fd0-4bbf-a6d1-9d3ea687ca51" />




## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

